### PR TITLE
(#16) Update Cake.Hosts NuGet package icon to the new Cake-Contrib logo for Cake addins

### DIFF
--- a/src/Cake.Hosts/Cake.Hosts.csproj
+++ b/src/Cake.Hosts/Cake.Hosts.csproj
@@ -21,7 +21,7 @@
     <Description>Cake Build addon to manipulate Hosts file</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://raw.githubusercontent.com/AMVSoftware/Cake.Hosts/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/cake-contrib-medium.png</PackageIconUrl>
+    <PackageIconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/addin/cake-contrib-addin-medium.png</PackageIconUrl>
     <PackageTags>cake hosts cake-build cake-contrib cake-addin</PackageTags>
     <IncludeSymbols>true</IncludeSymbols>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>


### PR DESCRIPTION
Closes #16
